### PR TITLE
Style updates

### DIFF
--- a/app/components/DataTable.js
+++ b/app/components/DataTable.js
@@ -111,30 +111,30 @@ export default class DataTable extends Component {
               <table>
                 <thead>
                   <tr>
-                    <td>Indicator</td>
-                    <td>{areaLabel(geography, areaProps)}</td>
-                    <td className="text-center" colSpan="3">{geographyType ? `All ${geographyType}s` : "Please select a geography"}</td>
+                    <th>Indicator</th>
+                    <th>{areaLabel(geography, areaProps)}</th>
+                    <th className="text-center" colSpan="3">{geographyType ? `All ${geographyType}s` : "Please select a geography"}</th>
                   </tr>
                   <tr>
-                    <td colSpan="2" />
-                    <td>
+                    <th colSpan="2" />
+                    <th>
                       {hasNotesAndSources(notesAndSources, "general", "average") &&
                         <span className="info-button" onClick={() => this.props.onInfoClick("general", "average")}>&#x24d8;&nbsp;</span>
                       }
                       Average
-                    </td>
-                    <td className="hide-for-mobile">
+                    </th>
+                    <th className="hide-for-mobile">
                       {hasNotesAndSources(notesAndSources, "general", "low") &&
                         <span className="info-button" onClick={() => this.props.onInfoClick("general", "low")}>&#x24d8;&nbsp;</span>
                       }
                       Low
-                    </td>
-                    <td className="hide-for-mobile">
+                    </th>
+                    <th className="hide-for-mobile">
                       {hasNotesAndSources(notesAndSources, "general", "high") &&
                         <span className="info-button" onClick={() => this.props.onInfoClick("general", "high")}>&#x24d8;&nbsp;</span>
                       }
                       High
-                    </td>
+                    </th>
                   </tr>
                 </thead>
                 <tbody>

--- a/app/components/DataTable.js
+++ b/app/components/DataTable.js
@@ -79,8 +79,8 @@ export default class DataTable extends Component {
                 <span className="moe">{marginOfError && `±${marginOfError}`}</span>
               </td>
               <td>{formatNumber(aggs.avg)}</td>
-              <td>{formatNumber(aggs.min)}</td>
-              <td>{formatNumber(aggs.max)}</td>
+              <td className="hide-for-mobile">{formatNumber(aggs.min)}</td>
+              <td className="hide-for-mobile">{formatNumber(aggs.max)}</td>
             </tr>
           );
         }
@@ -123,13 +123,13 @@ export default class DataTable extends Component {
                       }
                       Average
                     </td>
-                    <td>
+                    <td className="hide-for-mobile">
                       {hasNotesAndSources(notesAndSources, "general", "low") &&
                         <span className="info-button" onClick={() => this.props.onInfoClick("general", "low")}>&#x24d8;&nbsp;</span>
                       }
                       Low
                     </td>
-                    <td>
+                    <td className="hide-for-mobile">
                       {hasNotesAndSources(notesAndSources, "general", "high") &&
                         <span className="info-button" onClick={() => this.props.onInfoClick("general", "high")}>&#x24d8;&nbsp;</span>
                       }

--- a/app/styles/application.scss
+++ b/app/styles/application.scss
@@ -86,6 +86,9 @@ html.not-embedded body,
 @media screen and (max-width: $mobile-breakpoint) {
   .greater-dc-data-explorer .container {
     width: calc(100vw - 20px) !important;
+    .hide-for-mobile{
+      display: none;
+    }
   }
 }
 

--- a/app/styles/data-table.scss
+++ b/app/styles/data-table.scss
@@ -70,22 +70,27 @@
         padding: 10px 20px;
       }
 
-      thead td {
+      thead th {
         background: $filters-input-bg;
         color: white;
+        position: sticky;
+        padding: 5px 0;
       }
       thead tr{
         font-size: 80%;
       }
+
       thead tr:first-child{
         font-size: 80%;
-        td {
+        th {
           font-weight: bold;
           padding-bottom: 0;
+          top: 0;
         }
       }
-      thead tr:last-child td {
+      thead tr:last-child th {
         font-size: .75rem;
+        top: 21px;
       }
 
       tbody {

--- a/app/styles/data-table.scss
+++ b/app/styles/data-table.scss
@@ -74,13 +74,18 @@
         background: $filters-input-bg;
         color: white;
       }
-
-      thead tr:first-child td {
-        font-weight: bold;
-        padding-bottom: 0;
+      thead tr{
+        font-size: 80%;
+      }
+      thead tr:first-child{
+        font-size: 80%;
+        td {
+          font-weight: bold;
+          padding-bottom: 0;
+        }
       }
       thead tr:last-child td {
-        font-size: 1rem;
+        font-size: .75rem;
       }
 
       tbody {


### PR DESCRIPTION
- Reduces `theader` height
- Removes `High` and `Low` columns on mobile
- Makes `theader` **items** sticky. 

<img width="320" alt="screenshot 2018-03-09 14 49 51" src="https://user-images.githubusercontent.com/2237073/37226821-30b2f7e6-23a9-11e8-90cd-9b647db685a4.png">

<img width="717" alt="screenshot 2018-03-09 14 46 29" src="https://user-images.githubusercontent.com/2237073/37226676-bfb171e4-23a8-11e8-9e6e-723641158774.png">
