### PR TITLE
Add babel polyfills

### DIFF
--- a/app/initialize.js
+++ b/app/initialize.js
@@ -1,3 +1,4 @@
+require('babel-polyfill');
 import { h, render } from "preact";
 import App from "./components/App";
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "axios": "^0.17.1",
+    "babel-polyfill": "^6.26.0",
     "bluebird": "^3.5.1",
     "classnames": "^2.2.5",
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
This fixes errors with IE11 for `.find`, `.includes`, and probably a few others by adding a babel polyfill.