### PR TITLE
Downgrade csv-parse to correct issue with averages and chloropleth

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,6 @@ Updating existing data / adding new data
 #### Ignoring columns
 
 Because this application is designed to work with lots of different data sources, it is expected that some work will need to be done in order to maintain the application working as expected. To that end, one of the most important file is `app/constants/filters.js`. This file contains a list of all column names that should be ignored when building / displaying indicators in filters. Additionaly, all columns that end in `_nf`, `_m`, or `_moe` will be automatically ignored, without the need to manually add them to the blacklist.
+
+#### Issue with csv-parse
+We need to use an older version of csv-parse ^2.0.0 due to an issue with parsing. With version ^4.5.0 numbers are getting parsed as strings. It is likely a configuration setting that was introduced. This can be looked into in the future but for now we are just pinning it at ^2.0.0.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-select": "1.2.1"
   },
   "devDependencies": {
-    "csv-parse": "^4.8.2",
+    "csv-parse": "^2.0.0",
     "glob": "^7.1.2",
     "lodash.isequal": "^4.5.0",
     "minimist": "^1.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -242,7 +242,6 @@ export default class App extends Component {
     const dataKey = dataSourceKey(geography, topic);
     const data = dataSources[dataKey];
     const metadata = metadataSources[dataKey];
-
     return (
       <div className="greater-dc-data-explorer">
         <div className="App">

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -34,12 +34,12 @@ export default class DataTable extends Component {
     area: PropTypes.string,
     areaProps: PropTypes.object,
     data: PropTypes.array,
-    metadata: PropTypes.object,
-    notesAndSources: PropTypes.shape({
+    metadata: PropTypes.array,
+    notesAndSources: PropTypes.arrayOf(PropTypes.shape({
       geography: PropTypes.string,
       topic: PropTypes.string,
       indicator: PropTypes.string,
-    }),
+    })),
     selectedTab: PropTypes.string,
   }
 
@@ -100,7 +100,7 @@ export default class DataTable extends Component {
 
       rows.push(
         <tr className="separator" key={`${currentIndicator}-separator`}>
-          <td colSpan="5" class="separator" />
+          <td colSpan="5" className="separator" />
         </tr>
       );
     });

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { func, object } from "prop-types";
+import PropTypes, { func, object } from "prop-types";
 import classnames from "classnames";
 
 import Filters from './Filters';
@@ -54,8 +54,8 @@ export default class Map extends Component {
     selectedFilters: object,
     setArea: func.isRequired,
     toggleAreaLock: func.isRequired,
-    data: object,
-    metadata: object,
+    data: PropTypes.array,
+    metadata: PropTypes.array,
     onAboutAppClick: func.isRequired,
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3363,10 +3363,10 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csv-parse@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.8.2.tgz#c717cc8d87f619dbd556d5a15222a83b6d7a6d06"
-  integrity sha512-WfYwyJepTbjS5jWAWpVskOJ8Z10231HaFw6qJhSjGrpfMPf3yuoRohlasYsP/6/3YgTQcvZpTvoUo37eaei9Fw==
+csv-parse@^2.0.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-2.5.0.tgz#65748997ecc3719c594622db1b9ea0e2eb7d56bb"
+  integrity sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
We need to use an older version of csv-parse ^2.0.0 due to an issue with parsing. With version ^4.5.0 numbers are getting parsed as strings. It is likely a configuration setting that was introduced. This can be looked into in the future but for now we are just pinning it at ^2.0.0.